### PR TITLE
docs: update hyperlinks to opensource

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
 
   # Linter for markdown files.
 -   repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.44.0
+    rev: v0.45.0
     hooks:
     -   id: markdownlint
         args: ["--ignore", "docs/theoretical_documentation/model.md"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -232,11 +232,11 @@ make it much easier to do signoffs:
   https://github.com/scottrigby/dco-gh-ui ) for adding the signoff automatically
   to commits made with the GitHub browser UI
 * Additionally, it is possible to use shell scripting to automatically apply the
-  sign-off. For an example for bash to be put into a .bashrc file, see
-  [here](https://wiki.lfenergy.org/display/HOME/Contribution+and+Compliance+Guidelines+for+LF+Energy+Foundation+hosted+projects).
+  sign-off. For more info, check out
+  [an example for bash to be put into a .bashrc file](https://wiki.lfenergy.org/display/HOME/Contribution+and+Compliance+Guidelines+for+LF+Energy+Foundation+hosted+projects).
 * Alternatively, you can add `prepare-commit-msg hook` in .git/hooks directory.
-  For an example, see
-  [here](https://github.com/Samsung/ONE-vscode/wiki/ONE-vscode-Developer's-Certificate-of-Origin).
+  [Check out this example](https://github.com/Samsung/ONE-vscode/wiki/ONE-vscode-Developer's-Certificate-of-Origin)
+  for more info.
 
 ## Code reviews
 

--- a/README.md
+++ b/README.md
@@ -351,4 +351,4 @@ for submitting pull requests to us.
 ## Contact
 
 Please read [SUPPORT](https://github.com/alliander-opensource/transformer-thermal-model/blob/main/SUPPORT.md) for how to
-connect get into contact with the Transformer Thermal Model project.
+get in touch with the Transformer Thermal Model project.

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ cross-validation or analysis.
 ## License
 
 This project is licensed under the Mozilla Public License, version 2.0 - see
-[LICENSE](https://github.com/Alliander/transformer-thermal-model/blob/main/LICENSE) for details.
+[LICENSE](https://github.com/alliander-opensource/transformer-thermal-model/blob/main/LICENSE) for details.
 
 ## Licenses third-party libraries
 
@@ -336,16 +336,19 @@ which are licensed under their own respective Open-Source licenses.
 SPDX-License-Identifier headers are used to show which license is applicable.
 
 The concerning license files can be found in the
-[LICENSES](https://github.com/Alliander/transformer-thermal-model/blob/main/LICENSES) directory.
+[LICENSES](https://github.com/alliander-opensource/transformer-thermal-model/blob/main/LICENSES) directory.
 
 ## Contributing
 
-Please read [CODE_OF_CONDUCT](https://github.com/Alliander/transformer-thermal-model/blob/main/CODE_OF_CONDUCT.md),
-[CONTRIBUTING](https://github.com/Alliander/transformer-thermal-model/blob/main/CONTRIBUTING.md) and
-[PROJECT GOVERNANCE](https://github.com/Alliander/transformer-thermal-model/blob/main/GOVERNANCE.md) for details on the process
+Please read
+[CODE_OF_CONDUCT](https://github.com/alliander-opensource/transformer-thermal-model/blob/main/CODE_OF_CONDUCT.md),
+[CONTRIBUTING](https://github.com/alliander-opensource/transformer-thermal-model/blob/main/CONTRIBUTING.md)
+and
+[PROJECT GOVERNANCE](https://github.com/alliander-opensource/transformer-thermal-model/blob/main/GOVERNANCE.md)
+for details on the process
 for submitting pull requests to us.
 
 ## Contact
 
-Please read [SUPPORT](https://github.com/Alliander/transformer-thermal-model/blob/main/SUPPORT.md) for how to connect
-and get into contact with the Transformer Thermal Model project.
+Please read [SUPPORT](https://github.com/alliander-opensource/transformer-thermal-model/blob/main/SUPPORT.md) for how to
+connect get into contact with the Transformer Thermal Model project.

--- a/docs/get_started/about.md
+++ b/docs/get_started/about.md
@@ -327,7 +327,7 @@ cross-validation or analysis.
 ## License
 
 This project is licensed under the Mozilla Public License, version 2.0 - see
-[LICENSE](https://github.com/Alliander/transformer-thermal-model/blob/main/LICENSE) for details.
+[LICENSE](https://github.com/alliander-opensource/transformer-thermal-model/blob/main/LICENSE) for details.
 
 ## Licenses third-party libraries
 
@@ -336,16 +336,18 @@ which are licensed under their own respective Open-Source licenses.
 SPDX-License-Identifier headers are used to show which license is applicable.
 
 The concerning license files can be found in the
-[LICENSES](https://github.com/Alliander/transformer-thermal-model/blob/main/LICENSES) directory.
+[LICENSES](https://github.com/alliander-opensource/transformer-thermal-model/blob/main/LICENSES) directory.
 
 ## Contributing
 
-Please read [CODE_OF_CONDUCT](https://github.com/Alliander/transformer-thermal-model/blob/main/CODE_OF_CONDUCT.md),
-[CONTRIBUTING](https://github.com/Alliander/transformer-thermal-model/blob/main/CONTRIBUTING.md) and
-[PROJECT GOVERNANCE](https://github.com/Alliander/transformer-thermal-model/blob/main/GOVERNANCE.md) for details on the process
-for submitting pull requests to us.
+Please read
+[CODE_OF_CONDUCT](https://github.com/alliander-opensource/transformer-thermal-model/blob/main/CODE_OF_CONDUCT.md),
+[CONTRIBUTING](https://github.com/alliander-opensource/transformer-thermal-model/blob/main/CONTRIBUTING.md)
+and
+[PROJECT GOVERNANCE](https://github.com/alliander-opensource/transformer-thermal-model/blob/main/GOVERNANCE.md)
+for details on the process for submitting pull requests to us.
 
 ## Contact
 
-Please read [SUPPORT](https://github.com/Alliander/transformer-thermal-model/blob/main/SUPPORT.md) for how to connect
-and get into contact with the Transformer Thermal Model project.
+Please read [SUPPORT](https://github.com/alliander-opensource/transformer-thermal-model/blob/main/SUPPORT.md) for how to
+connect and get into contact with the Transformer Thermal Model project.

--- a/docs/index.md
+++ b/docs/index.md
@@ -118,7 +118,7 @@ The Transformer Thermal Model is designed with three major cases in mind:
 ## License
 
 This project is licensed under the Mozilla Public License, version 2.0 - see
-[LICENSE](https://github.com/Alliander/transformer-thermal-model/blob/main/LICENSE) for details.
+[LICENSE](https://github.com/alliander-opensource/transformer-thermal-model/blob/main/LICENSE) for details.
 
 ## Licenses third-party libraries
 
@@ -127,16 +127,18 @@ which are licensed under their own respective Open-Source licenses.
 SPDX-License-Identifier headers are used to show which license is applicable.
 
 The concerning license files can be found in the
-[LICENSES](https://github.com/Alliander/transformer-thermal-model/blob/main/LICENSES) directory.
+[LICENSES](https://github.com/alliander-opensource/transformer-thermal-model/blob/main/LICENSES) directory.
 
 ## Contributing
 
-Please read [CODE_OF_CONDUCT](https://github.com/Alliander/transformer-thermal-model/blob/main/CODE_OF_CONDUCT.md),
-[CONTRIBUTING](https://github.com/Alliander/transformer-thermal-model/blob/main/CONTRIBUTING.md) and
-[PROJECT GOVERNANCE](https://github.com/Alliander/transformer-thermal-model/blob/main/GOVERNANCE.md) for details on the process
-for submitting pull requests to us.
+Please read
+[CODE_OF_CONDUCT](https://github.com/alliander-opensource/transformer-thermal-model/blob/main/CODE_OF_CONDUCT.md),
+[CONTRIBUTING](https://github.com/alliander-opensource/transformer-thermal-model/blob/main/CONTRIBUTING.md)
+and
+[PROJECT GOVERNANCE](https://github.com/alliander-opensource/transformer-thermal-model/blob/main/GOVERNANCE.md)
+for details on the process for submitting pull requests to us.
 
 ## Contact
 
-Please read [SUPPORT](https://github.com/Alliander/transformer-thermal-model/blob/main/SUPPORT.md) for how to connect
-and get into contact with the Transformer Thermal Model project.
+Please read [SUPPORT](https://github.com/alliander-opensource/transformer-thermal-model/blob/main/SUPPORT.md) for how to
+connect and get into contact with the Transformer Thermal Model project.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@
 site_name: Transformer Thermal Model
 site_description: Simulate thermal behavior of power and distribution transformers.
 site_author: Contributors to the Transformer Thermal Model project
-site_url: https://github.com/Alliander/transformer-thermal-model
+site_url: https://github.com/alliander-opensource/transformer-thermal-model
 
 # https://www.mkdocs.org/user-guide/configuration/#validation
 validation:


### PR DESCRIPTION
There were some old links in our documentation that still needed to point to the new repo. I did a search to `Alliander/` and replaced it with `alliander-opensource/`. Should be sufficient I believe.