### PR TITLE
feature: setup sonarcloud scans

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -43,6 +43,6 @@ jobs:
           name: coverage.xml
           path: ./coverage.xml
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v4
+        uses: SonarSource/sonarqube-scan-action@v5
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -42,3 +42,7 @@ jobs:
         with:
           name: coverage.xml
           path: ./coverage.xml
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v4
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.10
+    rev: v0.11.11
     hooks:
       # Run the linter.
     -   id: ruff

--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ SPDX-License-Identifier: MPL-2.0
 -->
 # Transformer thermal model
 
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_transformer-thermal-model&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=alliander-opensource_transformer-thermal-model)
+[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_transformer-thermal-model&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=alliander-opensource_transformer-thermal-model)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_transformer-thermal-model&metric=coverage)](https://sonarcloud.io/summary/new_code?id=alliander-opensource_transformer-thermal-model)
+[![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_transformer-thermal-model&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=alliander-opensource_transformer-thermal-model)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_transformer-thermal-model&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=alliander-opensource_transformer-thermal-model)
+
 `transformer-thermal-model` is a library for modelling the transformer top-oil and
 hot-spot temperature based on the transformer specifications, a load profile and an ambient temperature profile.
 The model is an implementation according to the standard IEC 60076-7, also known as de Loading Guide.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,7 @@
+sonar.projectKey=alliander-opensource_transformer-thermal-model
+sonar.organization=alliander-opensource
+
+sonar.python.coverage.reportPaths=coverage.xml
+sonar.coverage.exclusions=\
+    **/tests/**, \
+    **/docs/**, \

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Contributors to the Transformer Thermal Model project
+#
+# SPDX-License-Identifier: MPL-2.0
+
 sonar.projectKey=alliander-opensource_transformer-thermal-model
 sonar.organization=alliander-opensource
 


### PR DESCRIPTION
This PR integrates SonarCloud scans into the automated GitHub Actions workflow. We opted to use GitHub Actions for running the scans instead of SonarCloud's automatic analysis to ensure that test coverage data is included in the reports.