### PR TITLE
Chore/add automated publish to test pypi

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Contributors to the Transformer Thermal Model project
+#
+# SPDX-License-Identifier: MPL-2.0
+name: (CI) publish Package
+permissions:
+  contents: read
+on:
+    push:
+
+jobs:
+  build-package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.13
+
+      - name: Install Poetry
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+      - name: Build package
+        run: poetry build
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: transformer-thermal-model-package
+          path: dist/
+  publish-to-testpypi:
+    name: Publish to TestPyPI
+    needs:
+    - build-package
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    environment:
+      name: pypi-test
+      url: https://test.pypi.org/p/transformer-thermal-model
+    permissions:
+      id-token: write
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: transformer-thermal-model-package
+        path: dist/
+    - name: Publish distribution 📦 to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,7 +5,7 @@ name: (CI) publish Package
 permissions:
   contents: read
 on:
-    push:
+    workflow_dispatch:
 
 jobs:
   build-package:
@@ -36,7 +36,6 @@ jobs:
     needs:
     - build-package
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
     environment:
       name: pypi-test
       url: https://test.pypi.org/p/transformer-thermal-model

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.11
+    rev: v0.11.12
     hooks:
       # Run the linter.
     -   id: ruff
@@ -27,7 +27,7 @@ repos:
     -   id: ruff-format
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
+    rev: v1.16.0
     hooks:
     -   id: mypy
         additional_dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "transformer-thermal-model"
-version = "0.1.0"
+version = "0.1.2"
 description = "Thermal model for transformers"
 authors = [{ name = "Contributors to the Transformer Thermal Model project" }]
 requires-python = "~=3.11"


### PR DESCRIPTION
This PR adds a simplified workflow to automate publishing the package to PyPI. The workflow is designed to be triggered manually and requires review by another member of the DALi team before execution, helping to prevent accidental releases.  
We use a **Trusted Publisher** setup to securely push releases to PyPI.