### PR TITLE
Chore: add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Contributors to the Transformer Thermal Model project
+#
+# SPDX-License-Identifier: MPL-2.0
+
+@alliander-opensource/dali
+
+.github/CODEOWNERS @GroenteLepel @Harm1995 @Jonasvdbo

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,6 @@
 
 * @alliander-opensource/dali
 
+# The following rule assigns ownership of the CODEOWNERS file itself. 
+# Note: The last matching rule takes precedence according to GitHub documentation.
 .github/CODEOWNERS @GroenteLepel @Harm1995 @Jonasvdbo

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,6 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-@alliander-opensource/dali
+* @alliander-opensource/dali
 
 .github/CODEOWNERS @GroenteLepel @Harm1995 @Jonasvdbo


### PR DESCRIPTION
Dependabot mentioned that it will step over to the CODEOWNERS file method of determining the reviewers. I also wanted to add this for any public PR's that will potentially be opened. Hence, I wanted to add the CODEOWNERS file.

I opted for adding our team as the overall codeowners.
I also added the main maintainers from our team as
owners of this file. This is a security tip that
I found in the documentation about the
CODEOWNERS file in GitHub:
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-and-branch-protection

Reading the documentation, if I understand correctly, the _last_ name will take precendence in this file. Knowing that, I thought this would be the right order? 