### PR TITLE
Feature/update model for three winding

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,11 +112,11 @@ def user_three_winding_transformer_specs() -> UserThreeWindingTransformerSpecifi
         no_load_loss=20,
         amb_temp_surcharge=10,
         lv_winding=WindingSpecifications(nom_load=1000, winding_oil_gradient=20),
-        mv_winding=WindingSpecifications(nom_load=2000, winding_oil_gradient=20),
-        hv_winding=WindingSpecifications(nom_load=3000, winding_oil_gradient=20),
-        load_loss_hv_lv=50,
+        mv_winding=WindingSpecifications(nom_load=1000, winding_oil_gradient=20),
+        hv_winding=WindingSpecifications(nom_load=1000, winding_oil_gradient=20),
+        load_loss_hv_lv=100,
         load_loss_hv_mv=100,
-        load_loss_mv_lv=150,
+        load_loss_mv_lv=100,
     )
 
 
@@ -125,7 +125,7 @@ def three_winding_input_profile() -> ThreeWindingInputProfile:
     """Create a three-winding input profile."""
     data_points = 10
     datetime_index = pd.date_range("2021-01-01 00:00:00", periods=data_points, freq="min")
-    load_profile_high_voltage_side = [1500] * data_points
+    load_profile_high_voltage_side = [4000] * data_points
     load_profile_middle_voltage_side = [1300] * data_points
     load_profile_low_voltage_side = [1300] * data_points
     ambient_temperature_profile = [30] * data_points

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,11 +123,11 @@ def user_three_winding_transformer_specs() -> UserThreeWindingTransformerSpecifi
 @pytest.fixture(scope="function")
 def three_winding_input_profile() -> ThreeWindingInputProfile:
     """Create a three-winding input profile."""
-    datetime_index = pd.date_range("2021-01-01 00:00:00", periods=3)
-    load_profile_high_voltage_side = [500, 500, 500]
-    load_profile_middle_voltage_side = [300, 300, 300]
-    load_profile_low_voltage_side = [300, 300, 300]
-    ambient_temperature_profile = [30, 30, 30]
+    datetime_index = pd.date_range("2021-01-01 00:00:00", periods=5)
+    load_profile_high_voltage_side = [500, 500, 500, 500, 500]
+    load_profile_middle_voltage_side = [300, 300, 300, 300, 300]
+    load_profile_low_voltage_side = [300, 300, 300, 300, 300]
+    ambient_temperature_profile = [30, 30, 30, 30, 30]
     return ThreeWindingInputProfile.create(
         datetime_index=datetime_index,
         ambient_temperature_profile=ambient_temperature_profile,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,9 +125,9 @@ def three_winding_input_profile() -> ThreeWindingInputProfile:
     """Create a three-winding input profile."""
     data_points = 10
     datetime_index = pd.date_range("2021-01-01 00:00:00", periods=data_points, freq="min")
-    load_profile_high_voltage_side = [4000] * data_points
-    load_profile_middle_voltage_side = [1300] * data_points
-    load_profile_low_voltage_side = [1300] * data_points
+    load_profile_high_voltage_side = [1000] * data_points
+    load_profile_middle_voltage_side = [1000] * data_points
+    load_profile_low_voltage_side = [1000] * data_points
     ambient_temperature_profile = [30] * data_points
     return ThreeWindingInputProfile.create(
         datetime_index=datetime_index,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,9 +111,9 @@ def user_three_winding_transformer_specs() -> UserThreeWindingTransformerSpecifi
     return UserThreeWindingTransformerSpecifications(
         no_load_loss=20,
         amb_temp_surcharge=10,
-        lv_winding=WindingSpecifications(nom_load=1000, winding_oil_gradient=500),
-        mv_winding=WindingSpecifications(nom_load=2000, winding_oil_gradient=1000),
-        hv_winding=WindingSpecifications(nom_load=3000, winding_oil_gradient=1500),
+        lv_winding=WindingSpecifications(nom_load=1000, winding_oil_gradient=20),
+        mv_winding=WindingSpecifications(nom_load=2000, winding_oil_gradient=20),
+        hv_winding=WindingSpecifications(nom_load=3000, winding_oil_gradient=20),
         load_loss_hv_lv=50,
         load_loss_hv_mv=100,
         load_loss_mv_lv=150,
@@ -123,11 +123,12 @@ def user_three_winding_transformer_specs() -> UserThreeWindingTransformerSpecifi
 @pytest.fixture(scope="function")
 def three_winding_input_profile() -> ThreeWindingInputProfile:
     """Create a three-winding input profile."""
-    datetime_index = pd.date_range("2021-01-01 00:00:00", periods=5)
-    load_profile_high_voltage_side = [500, 500, 500, 500, 500]
-    load_profile_middle_voltage_side = [300, 300, 300, 300, 300]
-    load_profile_low_voltage_side = [300, 300, 300, 300, 300]
-    ambient_temperature_profile = [30, 30, 30, 30, 30]
+    data_points = 10
+    datetime_index = pd.date_range("2021-01-01 00:00:00", periods=data_points, freq="min")
+    load_profile_high_voltage_side = [1500] * data_points
+    load_profile_middle_voltage_side = [1300] * data_points
+    load_profile_low_voltage_side = [1300] * data_points
+    ambient_temperature_profile = [30] * data_points
     return ThreeWindingInputProfile.create(
         datetime_index=datetime_index,
         ambient_temperature_profile=ambient_temperature_profile,

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -423,9 +423,5 @@ def test_three_winding_transformer(user_three_winding_transformer_specs, three_w
     results = thermal_model.run()
     top_oil_temp = results.top_oil_temp_profile
     hot_spot_temp = results.hot_spot_temp_profile
-    print(top_oil_temp)
-    print(hot_spot_temp)
-    print(hot_spot_temp["high_voltage_side"])
     assert top_oil_temp.shape == (len(three_winding_input_profile.datetime_index),)
     assert hot_spot_temp.shape == (len(three_winding_input_profile.datetime_index), 3)
-    assert False

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -11,6 +11,7 @@ from transformer_thermal_model.model import Model
 from transformer_thermal_model.schemas import UserTransformerSpecifications
 from transformer_thermal_model.toolbox.temp_sim_profile_tools import create_temp_sim_profile_from_df
 from transformer_thermal_model.transformer import PowerTransformer
+from transformer_thermal_model.transformer.threewinding import ThreeWindingTransformer
 
 
 @pytest.fixture
@@ -413,3 +414,18 @@ def test_if_rise_matches_iec(iec_load_profile):
         calculated_hot_spot_temp = hot_spot_temp_profile[timestamp]
         assert calculated_top_oil_temp == pytest.approx(expected["top_oil_temperature"], abs=1.5)
         assert calculated_hot_spot_temp == pytest.approx(expected["hot_spot_temperature"], abs=1.5)
+
+
+def test_three_winding_transformer(user_three_winding_transformer_specs, three_winding_input_profile):
+    """Test the three-winding transformer model."""
+    transformer = ThreeWindingTransformer(user_specs=user_three_winding_transformer_specs, cooling_type=CoolerType.ONAF)
+    thermal_model = Model(temperature_profile=three_winding_input_profile, transformer=transformer)
+    results = thermal_model.run()
+    top_oil_temp = results.top_oil_temp_profile
+    hot_spot_temp = results.hot_spot_temp_profile
+    print(top_oil_temp)
+    print(hot_spot_temp)
+    print(hot_spot_temp["high_voltage_side"])
+    assert top_oil_temp.shape == (len(three_winding_input_profile.datetime_index),)
+    assert hot_spot_temp.shape == (len(three_winding_input_profile.datetime_index), 3)
+    assert False

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -423,5 +423,6 @@ def test_three_winding_transformer(user_three_winding_transformer_specs, three_w
     results = thermal_model.run()
     top_oil_temp = results.top_oil_temp_profile
     hot_spot_temp = results.hot_spot_temp_profile
+    print(hot_spot_temp)
     assert top_oil_temp.shape == (len(three_winding_input_profile.datetime_index),)
     assert hot_spot_temp.shape == (len(three_winding_input_profile.datetime_index), 3)

--- a/tests/model/test_transformer.py
+++ b/tests/model/test_transformer.py
@@ -264,7 +264,7 @@ def test_initialize_three_winding_transformer(user_three_winding_transformer_spe
     """Initialize a ThreeWindingTransformer with the given user specifications."""
     transformer = ThreeWindingTransformer(user_specs=user_three_winding_transformer_specs, cooling_type=CoolerType.ONAN)
 
-    load_profile = three_winding_input_profile.load_profile
+    load_profile = three_winding_input_profile.load_profile_array
     end_temp_top_oil = transformer._end_temperature_top_oil(load_profile)
 
     assert transformer.specs.no_load_loss == user_three_winding_transformer_specs.no_load_loss

--- a/tests/schemas/test_threewinding.py
+++ b/tests/schemas/test_threewinding.py
@@ -31,14 +31,13 @@ def test_three_winding_transformer(user_three_winding_transformer_specs):
 
     assert transformer.lv_winding.nom_load == 1000
     assert transformer.time_const_oil == 180
-    assert (transformer.nominal_load_array == np.array([[3000], [2000], [1000]])).all()
-    assert (transformer.winding_oil_gradient_array == np.array([[1500], [1000], [500]])).all()
+    assert (transformer.nominal_load_array == np.array([[1000], [2000], [3000]])).all()
+    assert (transformer.winding_oil_gradient_array == np.array([[500], [1000], [1500]])).all()
 
 
 def test_three_winding_input_profile(three_winding_input_profile):
     """Test the creation of a three-winding input profile."""
-    assert len(three_winding_input_profile.datetime_index) == 3
-    assert len(three_winding_input_profile.load_profile) == 3
+    assert len(three_winding_input_profile.load_profile_array) == 3
 
 
 def test_wrong_three_winding_input_profile():

--- a/tests/schemas/test_threewinding.py
+++ b/tests/schemas/test_threewinding.py
@@ -31,8 +31,26 @@ def test_three_winding_transformer(user_three_winding_transformer_specs):
 
     assert transformer.lv_winding.nom_load == 1000
     assert transformer.time_const_oil == 180
-    assert (transformer.nominal_load_array == np.array([[1000], [2000], [3000]])).all()
-    assert (transformer.winding_oil_gradient_array == np.array([[500], [1000], [1500]])).all()
+    assert (
+        transformer.nominal_load_array
+        == np.array(
+            [
+                [user_three_winding_transformer_specs.lv_winding.nom_load],
+                [user_three_winding_transformer_specs.mv_winding.nom_load],
+                [user_three_winding_transformer_specs.hv_winding.nom_load],
+            ]
+        )
+    ).all()
+    assert (
+        transformer.winding_oil_gradient_array
+        == np.array(
+            [
+                [user_three_winding_transformer_specs.lv_winding.winding_oil_gradient],
+                [user_three_winding_transformer_specs.mv_winding.winding_oil_gradient],
+                [user_three_winding_transformer_specs.hv_winding.winding_oil_gradient],
+            ]
+        )
+    ).all()
 
 
 def test_three_winding_input_profile(three_winding_input_profile):

--- a/tests/schemas/test_threewinding.py
+++ b/tests/schemas/test_threewinding.py
@@ -29,7 +29,7 @@ def test_three_winding_transformer(user_three_winding_transformer_specs):
         defaults=defaults, user=user_three_winding_transformer_specs
     )
 
-    assert transformer.lv_winding.nom_load == 1000
+    assert transformer.lv_winding.nom_load == user_three_winding_transformer_specs.lv_winding.nom_load
     assert transformer.time_const_oil == 180
     assert (
         transformer.nominal_load_array

--- a/transformer_thermal_model/model/thermal_model.py
+++ b/transformer_thermal_model/model/thermal_model.py
@@ -289,7 +289,9 @@ class Model:
                     index=self.data.datetime_index,
                 ),
             )
-        return OutputProfile(
-            top_oil_temp_profile=pd.Series(top_oil_temp_profile, index=self.data.datetime_index),
-            hot_spot_temp_profile=pd.Series(hot_spot_temp_profile, index=self.data.datetime_index),
-        )
+        else:
+            # For a two winding transformer, hot_spot_temp_profile is a Series
+            return OutputProfile(
+                top_oil_temp_profile=pd.Series(top_oil_temp_profile, index=self.data.datetime_index),
+                hot_spot_temp_profile=pd.Series(hot_spot_temp_profile, index=self.data.datetime_index),
+            )

--- a/transformer_thermal_model/model/thermal_model.py
+++ b/transformer_thermal_model/model/thermal_model.py
@@ -282,7 +282,7 @@ class Model:
                 top_oil_temp_profile=pd.Series(top_oil_temp_profile, index=self.data.datetime_index),
                 hot_spot_temp_profile=pd.DataFrame(
                     hot_spot_temp_profile.transpose(),
-                    columns=["high_voltage_side", "middle_voltage_side", "low_voltage_side"],
+                    columns=["low_voltage_side", "middle_voltage_side", "high_voltage_side"],
                     index=self.data.datetime_index,
                 ),
             )

--- a/transformer_thermal_model/model/thermal_model.py
+++ b/transformer_thermal_model/model/thermal_model.py
@@ -172,12 +172,12 @@ class Model:
             np.ndarray: The computed top-oil temperature profile over time.
         """
         top_oil_temp_profile = np.zeros_like(t_internal, dtype=np.float64)
-        top_oil_temp = t_internal[0] if self.init_top_oil_temp is None else self.init_top_oil_temp
-        top_oil_temp_profile[0] = top_oil_temp
+        top_oil_temp_profile[0] = t_internal[0] if self.init_top_oil_temp is None else self.init_top_oil_temp
 
         for i in range(1, len(t_internal)):
-            top_oil_temp = self._update_top_oil_temp(top_oil_temp, t_internal[i], top_k[i], f1[i])
-            top_oil_temp_profile[i] = top_oil_temp
+            top_oil_temp_profile[i]  = self._update_top_oil_temp(top_oil_temp_profile[i-1], 
+                                                                 t_internal[i], top_k[i], f1[i])
+
 
         return top_oil_temp_profile
 

--- a/transformer_thermal_model/model/thermal_model.py
+++ b/transformer_thermal_model/model/thermal_model.py
@@ -219,7 +219,7 @@ class Model:
                     hot_spot_increase_oil, static_hot_spot_incr_oil[i], f2_oil[i]
                 )
                 hot_spot_temp_profile[i] = top_oil_temp_profile[i] + hot_spot_increase_windings - hot_spot_increase_oil
-        
+
         # for a three winding transformer with multiple load profiles:
         else:
             hot_spot_temp_profile[:, 0] = top_oil_temp_profile[0]
@@ -238,8 +238,6 @@ class Model:
                     )
 
         return hot_spot_temp_profile
-
-
 
     def _update_top_oil_temp(self, current_temp: float, t_internal: float, top_k: float, f1: float) -> float:
         """Update the top-oil temperature for a single time step."""

--- a/transformer_thermal_model/schemas/specifications/transformer.py
+++ b/transformer_thermal_model/schemas/specifications/transformer.py
@@ -226,15 +226,21 @@ class ThreeWindingTransformerSpecifications(BaseTransformerSpecifications):
     @property
     def nominal_load_array(cls) -> np.ndarray:
         """Return the nominal loads as a numpy array."""
-        return np.array([[cls.hv_winding.nom_load], [cls.mv_winding.nom_load], [cls.lv_winding.nom_load]])
+        return np.array(
+            [
+                [cls.lv_winding.nom_load],
+                [cls.mv_winding.nom_load],
+                [cls.hv_winding.nom_load],
+            ]
+        )
 
     @property
     def winding_oil_gradient_array(cls) -> np.ndarray:
         """Return the winding oil gradient as a numpy array."""
         return np.array(
             [
-                [cls.hv_winding.winding_oil_gradient],
-                [cls.mv_winding.winding_oil_gradient],
                 [cls.lv_winding.winding_oil_gradient],
+                [cls.mv_winding.winding_oil_gradient],
+                [cls.hv_winding.winding_oil_gradient],
             ]
         )

--- a/transformer_thermal_model/schemas/thermal_model/input_profile.py
+++ b/transformer_thermal_model/schemas/thermal_model/input_profile.py
@@ -201,13 +201,13 @@ class ThreeWindingInputProfile(BaseInputProfile):
     load_profile_low_voltage_side: np.typing.NDArray[np.float64]
 
     @property
-    def load_profile(self) -> np.typing.NDArray[np.float64]:
+    def load_profile_array(self) -> np.typing.NDArray[np.float64]:
         """Return an array with shape (3,n) of the three load profiles (high, middle, low voltage sides)."""
         return np.array(
             [
-                self.load_profile_high_voltage_side,
-                self.load_profile_middle_voltage_side,
                 self.load_profile_low_voltage_side,
+                self.load_profile_middle_voltage_side,
+                self.load_profile_high_voltage_side,
             ]
         )
 

--- a/transformer_thermal_model/schemas/thermal_model/output_profile.py
+++ b/transformer_thermal_model/schemas/thermal_model/output_profile.py
@@ -16,7 +16,7 @@ class OutputProfile(BaseModel):
     """
 
     top_oil_temp_profile: pd.Series
-    hot_spot_temp_profile: pd.Series
+    hot_spot_temp_profile: pd.Series | pd.DataFrame
 
     def convert_to_dataframe(self) -> pd.DataFrame:
         """Process the two pandas Series and convert them to a single dataframe, linked by the timestamp."""

--- a/transformer_thermal_model/transformer/threewinding.py
+++ b/transformer_thermal_model/transformer/threewinding.py
@@ -66,7 +66,7 @@ class ThreeWindingTransformer(Transformer):
             cooling_type=cooling_type,
         )
         self.specs = ThreeWindingTransformerSpecifications.create(self.defaults, user_specs)
-        logger.debug("Initialized ThreePhaseTransformer with specifications: %s", user_specs)
+        logger.debug("Initialized ThreeWindingTransformer with specifications: %s", user_specs)
 
     @property
     def defaults(self) -> DefaultTransformerSpecifications:
@@ -117,9 +117,9 @@ class ThreeWindingTransformer(Transformer):
 
     def _end_temperature_top_oil(self, load_profile: np.ndarray) -> np.ndarray:
         """Calculate the end temperature of the top-oil."""
-        hv_rise = self._get_loss_hc() * np.power(load_profile[0] / self.specs.hv_winding.nom_load, 2)
-        mv_rise = self._get_loss_mc() * np.power(load_profile[1] / self.specs.mv_winding.nom_load, 2)
         lv_rise = self._get_loss_lc() * np.power(load_profile[2] / self.specs.lv_winding.nom_load, 2)
+        mv_rise = self._get_loss_mc() * np.power(load_profile[1] / self.specs.mv_winding.nom_load, 2)
+        hv_rise = self._get_loss_hc() * np.power(load_profile[0] / self.specs.hv_winding.nom_load, 2)
 
         end_temp_top_oil = (
             self._pre_factor * (hv_rise + mv_rise + lv_rise + self.specs.no_load_loss) / self.specs.load_loss_total

--- a/transformer_thermal_model/transformer/threewinding.py
+++ b/transformer_thermal_model/transformer/threewinding.py
@@ -117,9 +117,9 @@ class ThreeWindingTransformer(Transformer):
 
     def _end_temperature_top_oil(self, load_profile: np.ndarray) -> np.ndarray:
         """Calculate the end temperature of the top-oil."""
-        lv_rise = self._get_loss_lc() * np.power(load_profile[2] / self.specs.lv_winding.nom_load, 2)
+        lv_rise = self._get_loss_lc() * np.power(load_profile[0] / self.specs.lv_winding.nom_load, 2)
         mv_rise = self._get_loss_mc() * np.power(load_profile[1] / self.specs.mv_winding.nom_load, 2)
-        hv_rise = self._get_loss_hc() * np.power(load_profile[0] / self.specs.hv_winding.nom_load, 2)
+        hv_rise = self._get_loss_hc() * np.power(load_profile[2] / self.specs.hv_winding.nom_load, 2)
 
         end_temp_top_oil = (
             self._pre_factor * (hv_rise + mv_rise + lv_rise + self.specs.no_load_loss) / self.specs.load_loss_total


### PR DESCRIPTION
Here we change the model class to handle the calculations for the three winding transformer. to do this we splitted the calculation fo the top_oil temperature and the hotspot temperature. This was done since the calculation of the top_oil stayed mostly the same, while the calculations of the hotspot required an additional for loop, to loop over the different load_profiles. 