### PR TITLE
Docs: Update TransformerType enum attributes.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.13.0
+    rev: v0.13.1
     hooks:
       # Run the linter.
     -   id: ruff
@@ -27,7 +27,7 @@ repos:
     -   id: ruff-format
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.18.1
+    rev: v1.18.2
     hooks:
     -   id: mypy
         additional_dependencies:

--- a/transformer_thermal_model/transformer/enums/transformer_type.py
+++ b/transformer_thermal_model/transformer/enums/transformer_type.py
@@ -14,6 +14,7 @@ class TransformerType(StrEnum):
     Attributes:
         POWER (str): Power transformer.
         DISTRIBUTION (str): Distribution transformer.
+        THREE_WINDING (str): Three winding transformer.
     """
 
     POWER = "power"


### PR DESCRIPTION
Add the THREE_WINDING to the attributes in the docstring because it was missing.

Secondly I had to update the pre-commit settings for ruff and mypy in order to commit.