### PR TITLE
chore: configure Dependabot for pre-commit and github-actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,7 +9,22 @@
 
 version: 2
 updates:
+  # enable version updates for our dependencies
   - package-ecosystem: "pip" # `pip` also enables Poetry
     directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+
+  # enable version updates for our pre-commit hooks.
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # enable version updates for our pre-commit hooks
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`
+    # You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.
+    directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -21,7 +21,7 @@ updates:
     schedule:
       interval: "weekly"
 
-  # enable version updates for our pre-commit hooks
+  # enable version updates for our github-actions
   - package-ecosystem: "github-actions"
     # Workflow files stored in the default location of `.github/workflows`
     # You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,11 +6,6 @@
 # 'pip install pre-commit'.
 # 'pre-commit install'.
 repos:
--   repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
-    rev: v0.9.0
-    hooks:
-    -   id: pre-commit-update
-
 -   repo: https://github.com/fsfe/reuse-tool
     rev: v6.2.0
     hooks:


### PR DESCRIPTION
Since a recent update we now have the ability to check our versions in github-actions and pre-commit via dependabot. It also should be able to do this with SHA pins, according to the news post: https://github.blog/changelog/2026-03-10-dependabot-now-supports-pre-commit-hooks/