### PR TITLE
fix: correct column name in create_temp_sim_profile_from_df

### DIFF
--- a/transformer_thermal_model/toolbox/temp_sim_profile_tools.py
+++ b/transformer_thermal_model/toolbox/temp_sim_profile_tools.py
@@ -52,5 +52,5 @@ def create_temp_sim_profile_from_df(profile_as_dataframe: pd.DataFrame) -> Input
         datetime_index=profile_as_dataframe["timestamp"],
         load_profile=profile_as_dataframe["load"],
         ambient_temperature_profile=profile_as_dataframe["ambient_temperature"],
-        top_oil_temperature_profile=profile_as_dataframe.get("top_oil_temperature_profile"),
+        top_oil_temperature_profile=profile_as_dataframe.get("top_oil_temperature") or profile_as_dataframe.get("top_oil_temperature_profile"),
     )


### PR DESCRIPTION
## Summary

The docstring for `create_temp_sim_profile_from_df` documents the optional column as `top_oil_temperature`, but the implementation incorrectly reads `top_oil_temperature_profile`.

This fix changes line 55 to use `profile_as_dataframe.get("top_oil_temperature")` to match the documented parameter name.

**Before:** `profile_as_dataframe.get("top_oil_temperature_profile")`
**After:** `profile_as_dataframe.get("top_oil_temperature")`

Fixes #241