### PR TITLE
refactor: simplify time step conversion

### DIFF
--- a/transformer_thermal_model/schemas/thermal_model/input_profile.py
+++ b/transformer_thermal_model/schemas/thermal_model/input_profile.py
@@ -36,7 +36,7 @@ class BaseInputProfile(BaseModel):
         """
         # Calculate time steps in minutes
         time_deltas = (
-            np.diff(self.datetime_index, prepend=self.datetime_index[0]).astype("timedelta64[s]").astype(float) / 60
+            np.diff(self.datetime_index, prepend=self.datetime_index[0]).astype("timedelta64[m]").astype(float)
         )
         return time_deltas
 


### PR DESCRIPTION
Fixes #243

## Summary
- Cast datetime deltas directly to minutes in `BaseInputProfile.time_step` instead of seconds followed by `/ 60`.

## Tests
- `uv run ruff check transformer_thermal_model/schemas/thermal_model/input_profile.py`
- `uv run ruff format --check transformer_thermal_model/schemas/thermal_model/input_profile.py`
- `uv run mypy transformer_thermal_model/schemas/thermal_model/input_profile.py`
- `uv run pytest tests/schemas/test_thermal_model_profile_input.py`

Note: `uv run pre-commit run --files transformer_thermal_model/schemas/thermal_model/input_profile.py` was attempted but timed out while installing hook environments locally.