### PR TITLE
Fix: type in dio in CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: "If you are using Transformer Thermal Model in your research work, plea
 
 title: "alliander-opensource/transformer-thermal-model"
 url: "https://github.com/alliander-opensource/transformer-thermal-model"
-doi: "DOI: 10.5281/zenodo.17434809"
+doi: "10.5281/zenodo.17434809"
 license: "MPL-2.0"
 authors:
   - family-names: "Boerma"


### PR DESCRIPTION
This PR fixes a small typo in the DOI reference where the DOI: prefix was duplicated.